### PR TITLE
Provide a safer default namespace for GetResourceAccess

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -279,7 +279,7 @@ func addUniqueItems(itemlist []string, itemsToAdd ...string) []string {
 // configured for the user.
 //
 // - namespace is the namespace to set  in the selfsubjectaccessreview call, if not specified
-// it defaults to "default"
+// it defaults to an invalid namespace to limit the response to cluster scoped resources.
 func makeSubjectAccessRulesReviewForUser(
 	kclient kubernetes.Interface, namespace string,
 ) ([]authorizationv1.ResourceRule, error) {
@@ -293,7 +293,9 @@ func makeSubjectAccessRulesReviewForUser(
 	// if the call is successful then this function returns a list of resourcerules
 
 	if namespace == "" {
-		namespace = "default"
+		// This is a workaround for SelfSubjectRulesReview errantly accepting RoleBindings on the default namespace
+		// for cluster scoped access. Only ClusterRoleBindings actually affect access.
+		namespace = "$ Invalid $"
 	}
 
 	sarr := &authorizationv1.SelfSubjectRulesReview{

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -215,10 +215,12 @@ func TestMakeSubjectAccessRulesReviewForUser(t *testing.T) {
 		{"user-no-specific-access", testUsers["user-no-specific-access"].KubeClient, "", 1},
 		// basic rule + access to red-metrics + access to blue-metrics
 		{"user-purple", testUsers["user-purple"].KubeClient, "", 3},
+		{"user-view-all-default-namespace", testUsers["user-view-all-default-namespace"].KubeClient, "", 1},
+		{"user-view-all-default-namespace", testUsers["user-view-all-default-namespace"].KubeClient, "default", 2},
 	}
 
 	for _, test := range testcases {
-		accessrules, err := makeSubjectAccessRulesReviewForUser(test.kubeClient, "")
+		accessrules, err := makeSubjectAccessRulesReviewForUser(test.kubeClient, test.namespace)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}


### PR DESCRIPTION
When checking cluster-scoped access, GetResourceAccess was errantly accounting for role bindings in the default namespace event though only cluster role bindings should affect access.

Relates:
https://issues.redhat.com/browse/ACM-10162